### PR TITLE
Don't create ids that start with a number

### DIFF
--- a/src/calibre/ebooks/oeb/polish/toc.py
+++ b/src/calibre/ebooks/oeb/polish/toc.py
@@ -202,7 +202,7 @@ def ensure_id(elem):
     elem_id = elem.get('id', None)
     if elem_id:
         return False, elem_id
-    elem.set('id', uuid_id())
+    elem.set('id', 'u' + uuid_id())
     return True, elem.get('id')
 
 def elem_to_toc_text(elem):
@@ -392,7 +392,7 @@ def add_id(container, name, loc, totals=None):
                                     ' before editing.') % name)
         container.replace(name, root)
 
-    node.set('id', node.get('id', uuid_id()))
+    node.set('id', node.get('id', 'u' + uuid_id()))
     container.commit_item(name, keep_parsed=True)
     return node.get('id')
 
@@ -461,7 +461,7 @@ def commit_toc(container, toc, lang=None, uid=None):
         if eid:
             m = container.opf_xpath('//*[@id="%s"]'%eid)
             if m:
-                uid = xml2text(m[0])
+                uid = 'u' + xml2text(m[0])
 
     title = _('Table of Contents')
     m = container.opf_xpath('//dc:title')


### PR DESCRIPTION
Per the XML specification for ids, xml:ids should not start with a number.  This changeset prepends a 'u' to the uuid strings generated, so they are compliant with the value spec for xml ids.

Id spec: http://www.w3.org/TR/xmlschema-2/#ID

```
The ·value space· of ID is the set of all strings that ·match· the NCName production in [Namespaces in XML]. 
```

Name Spec: http://www.w3.org/TR/REC-xml/#NT-Name

```
[4]     NameStartChar      ::=      ":" | [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x2FF] | [#x370-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]
```

This is a problem because ePubCheck uses Jing, which enforces this:
https://github.com/IDPF/epubcheck/issues/307
https://code.google.com/p/jing-trang/issues/detail?id=174
